### PR TITLE
perf(api): replace PostgreSQL camelCase converter with PHP-native call

### DIFF
--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/System/BackEnd/Helper_API.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/System/BackEnd/Helper_API.php
@@ -411,37 +411,13 @@ namespace App\Helpers\ZhtHelper\System\BackEnd
                     }
                 else
                     {
-//$varSignConvertPHPArrayToJSONCamelCase = FALSE;
-                    //$varReturn = \App\Helpers\ZhtHelper\General\Helper_Array::getArrayKeyRename_CamelCase($varUserSession, $varDataSend);
                     if ($varSignConvertPHPArrayToJSONCamelCase == TRUE)
                         {
-                        $varReturn = 
-                            \App\Helpers\ZhtHelper\Database\Helper_PostgreSQL::getQueryExecution(
-                                $varUserSession, 
-                                \App\Helpers\ZhtHelper\Database\Helper_PostgreSQL::getBuildStringLiteral_StoredProcedure(
-                                    $varUserSession,
-                                    'SchSysAsset.Func_General_JSONArray_ConvertKeysToCamelCase',
-                                    [
-                                        [
-                                        \App\Helpers\ZhtHelper\General\Helper_Encode::getJSONEncode(
-                                            $varUserSession,
-                                            $varDataSend
-                                            ),
-                                        'json'
-                                        ]
-                                    ]
-                                    )
-                                );
-                        //dd($varReturn);
-
-                        $varReturn['data'] =
-                            \App\Helpers\ZhtHelper\General\Helper_Encode::getJSONDecode(
-                                $varUserSession,
-                                $varReturn['data'][0]['Func_General_JSONArray_ConvertKeysToCamelCase']
-                                );
-
                         $varReturn =
-                            $varReturn['data'];
+                            \App\Helpers\ZhtHelper\General\Helper_Array::getArrayKeyRename_CamelCase(
+                                $varUserSession,
+                                $varDataSend
+                                );
                         }
                     else
                         {


### PR DESCRIPTION
## Summary

- Drop the `SchSysAsset.Func_General_JSONArray_ConvertKeysToCamelCase` stored-proc call inside `Helper_API::getEngineDataSend_DataRead`.
- Route the camelCase conversion through the existing pure-PHP helper `Helper_Array::getArrayKeyRename_CamelCase`.
- Removes 1 PostgreSQL roundtrip plus a JSON encode/decode cycle from every successful API data-read response.

## Why

`getEngineDataSend_DataRead` is on the hot path of every `transaction.read.*` engine. Previously each response payload was JSON-encoded in PHP, shipped to PostgreSQL via `Helper_PostgreSQL::getQueryExecution`, transformed inside a plpgsql stored procedure, then JSON-decoded back into PHP. The stored proc has exactly one call site in the codebase, and a pure-PHP implementation with identical semantics already exists (preserves all-caps prefixes such as `Sys_ID -> sys_ID`, `PhoneNumber -> phoneNumber`). Switching the caller eliminates a per-request network roundtrip and the redundant JSON serialization cycle while keeping the response shape identical.

## Behavior

- `Sys_ID`, `Tax_ID`, all-caps prefixes -> preserved as `sys_ID`, `tax_ID` (matches existing supplier list sample output).
- Standard PascalCase keys -> first letter lowercased (`PhoneNumber` -> `phoneNumber`).
- Nested arrays -> recursed identically to the prior plpgsql implementation.
- Empty / non-array input -> still throws the same `Empty Data Result` / `Data Read Failed` exceptions; no behavioral change at the boundary.

## Test plan

- [ ] Hit `transaction.read.dataList.supplyChain.getSupplierList` and confirm response keys are unchanged (`sys_ID`, `code`, `name`, `tax_ID`, `phoneNumber`, ...).
- [ ] Spot-check 2-3 other `transaction.read.*` engines (e.g. `getWarehouseInboundOrderDetail`, any `getDataList_*`) and verify response key shape matches pre-change.
- [ ] Verify nested array fields (e.g. detail arrays) preserve their key casing recursively.
- [ ] Confirm error paths still surface `Empty Data Result` and `Data Read Failed` exceptions.
- [ ] Light load smoke check on a read-heavy endpoint to confirm latency moves in the expected direction.

## Follow-up

- Stored procedure `SchSysAsset.Func_General_JSONArray_ConvertKeysToCamelCase` is now orphaned. Safe to drop after deploy + a final grep across all consumer repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)