### PR TITLE
perf(auth): collapse Redis calls and rehydrate APIWebToken cache on miss

### DIFF
--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/System/BackEnd/Helper_API.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/System/BackEnd/Helper_API.php
@@ -1275,20 +1275,20 @@ if (strcmp($varAPIKey, 'transaction.read.dataList.finance.getAdvance')==0)
             catch (Exception $ex) {
                 }
 
-            //---> Get Value From Cache
-            if (\App\Helpers\ZhtHelper\Cache\Helper_Redis::isExpired(
-                $varUserSession,
-                'ERPReborn::APIWebToken::'.$varAPIWebToken
-                ) == false) {
-                $varData = (
+            //---> Get Value From Cache (single Redis GET; null/empty means miss or expired)
+            $varRedisKey       = 'ERPReborn::APIWebToken::'.$varAPIWebToken;
+            $varRedisRawPayload =
+                \App\Helpers\ZhtHelper\Cache\Helper_Redis::getValue(
+                    $varUserSession,
+                    $varRedisKey
+                    );
+
+            if ($varRedisRawPayload !== null && $varRedisRawPayload !== '' && $varRedisRawPayload !== false) {
+                $varData =
                     \App\Helpers\ZhtHelper\General\Helper_Encode::getJSONDecode(
                         $varUserSession,
-                        \App\Helpers\ZhtHelper\Cache\Helper_Redis::getValue(
-                            $varUserSession,
-                            'ERPReborn::APIWebToken::'.$varAPIWebToken
-                            )
-                        )
-                    );
+                        $varRedisRawPayload
+                        );
 
                 $varReturn['userLoginSessionID'] = $varData['userLoginSession_RefID'];
                 $varReturn['userID'] = $varData['user_RefID'];
@@ -1299,69 +1299,103 @@ if (strcmp($varAPIKey, 'transaction.read.dataList.finance.getAdvance')==0)
                 $varReturn['sessionAutoFinishDateTimeTZ'] = $varData['sessionAutoFinishDateTimeTZ'];
 
                 if (\App\Helpers\ZhtHelper\General\Helper_Array::isKeyExist($varUserSession, 'userIdentities', $varData)) {
-                    $varReturn['userIdentities'] = 
+                    $varReturn['userIdentities'] =
                         //null;
                         self::getUserIdentity(
                             $varUserSession,
                             $varData['userIdentities']['LDAPUserID']
                             ); //---> Data Diambil dari DB (Lebih update bila ada perubahan data)
-                        //$varData['userIdentities']; //---> Data Diambil dari Redis (Lebih responsif tapi tidak adaptif)                    
+                        //$varData['userIdentities']; //---> Data Diambil dari Redis (Lebih responsif tapi tidak adaptif)
                     }
                 }
-            //---> Get Value From Database
+            //---> Cache Miss : Fall Back to Database + Write-Back
             else
                 {
                 if ((new \App\Models\Database\SchSysConfig\General())->isExist_APIWebToken($varUserSession, $varAPIWebToken) == true)
                     {
                     //---> Jika $varAPIWebToken merupakan Web Token System (SysEngine)
-                    if (strcmp($varAPIWebToken, \App\Helpers\ZhtHelper\System\Helper_Environment::getAPIWebToken_System()) == 0) 
+                    if (strcmp($varAPIWebToken, \App\Helpers\ZhtHelper\System\Helper_Environment::getAPIWebToken_System()) == 0)
                         {
                         $varReturn['userLoginSessionID'] = \App\Helpers\ZhtHelper\System\Helper_Environment::getUserSessionID_System();
                         $varReturn['branchID'] = 11000000000001;
                         }
-                    /*
+                    //---> Token milik user normal. Rehydrate Redis dari TblLog_UserLoginSession.OptionsList
                     else
                         {
-                        $varData = 
-                            \App\Helpers\ZhtHelper\General\Helper_Encode::getJSONDecode(
-                                $varUserSession,
-                                \App\Helpers\ZhtHelper\Cache\Helper_Redis::getValue(
-                                    $varUserSession,
-                                    'ERPReborn::APIWebToken::'.$varAPIWebToken
-                                    )
-                                );
-                        //dd($varData['userIdentities']['LDAPUserID']);
+                        try {
+                            $varSessionRows =
+                                (new \App\Models\Database\SchSysConfig\TblLog_UserLoginSession())
+                                    ->getAllFilteredDataRecord(
+                                        $varUserSession,
+                                        '"APIWebToken" = \''.$varAPIWebToken.'\''
+                                        );
 
-                        $varReturn['userLoginSessionID'] = $varData['userLoginSession_RefID'];
-                        $varReturn['userID'] = $varData['user_RefID'];
-                        $varReturn['userRoleID'] = $varData['userRole_RefID'];
-                        $varReturn['branchID'] = $varData['branch_RefID'];
-                        $varReturn['sessionStartDateTimeTZ'] = $varData['sessionStartDateTimeTZ'];
-                        $varReturn['sessionAutoStartDateTimeTZ'] = $varData['sessionAutoStartDateTimeTZ'];
-                        $varReturn['sessionAutoFinishDateTimeTZ'] = $varData['sessionAutoFinishDateTimeTZ'];
-                        //---> Bila $varReturn['userIdentities'] diambil Redis, data tidak terupdate apabila ada perubahan pada database 
+                            if (is_array($varSessionRows) && count($varSessionRows) > 0)
+                                {
+                                $varSessionRow = $varSessionRows[0];
 
-                        //if(\App\Helpers\ZhtHelper\General\Helper_Array::isKeyExist($varUserSession, 'userPrivilegesMenu', $varData))
-                        //    {
-                        //    $varReturn['userPrivilegesMenu'] = \App\Helpers\ZhtHelper\General\Helper_Encode::getJSONDecode($varUserSession, $varData['userPrivilegesMenu']);
-                        //    }
-                        //$varReturn['environment'] = $varData['environment'];
-                        if (\App\Helpers\ZhtHelper\General\Helper_Array::isKeyExist($varUserSession, 'environment', $varData)) {
-                            $varReturn['environment'] = $varData['environment'];
+                                //---> OptionsList kolom JSON yang menyimpan payload identik dengan struktur Redis
+                                $varData =
+                                    \App\Helpers\ZhtHelper\General\Helper_Encode::getJSONDecode(
+                                        $varUserSession,
+                                        $varSessionRow['OptionsList']
+                                        );
+
+                                if (is_array($varData))
+                                    {
+                                    $varReturn['userLoginSessionID']          = isset($varData['userLoginSession_RefID'])       ? $varData['userLoginSession_RefID']       : null;
+                                    $varReturn['userID']                      = isset($varData['user_RefID'])                   ? $varData['user_RefID']                   : null;
+                                    $varReturn['userRoleID']                  = isset($varData['userRole_RefID'])               ? $varData['userRole_RefID']               : null;
+                                    $varReturn['branchID']                    = isset($varData['branch_RefID'])                 ? $varData['branch_RefID']                 : null;
+                                    $varReturn['sessionStartDateTimeTZ']      = isset($varData['sessionStartDateTimeTZ'])       ? $varData['sessionStartDateTimeTZ']       : null;
+                                    $varReturn['sessionAutoStartDateTimeTZ']  = isset($varData['sessionAutoStartDateTimeTZ'])   ? $varData['sessionAutoStartDateTimeTZ']   : null;
+                                    $varReturn['sessionAutoFinishDateTimeTZ'] = isset($varData['sessionAutoFinishDateTimeTZ'])  ? $varData['sessionAutoFinishDateTimeTZ']  : null;
+
+                                    if (\App\Helpers\ZhtHelper\General\Helper_Array::isKeyExist($varUserSession, 'userIdentities', $varData)) {
+                                        $varReturn['userIdentities'] =
+                                            self::getUserIdentity(
+                                                $varUserSession,
+                                                $varData['userIdentities']['LDAPUserID']
+                                                );
+                                        }
+
+                                    if (\App\Helpers\ZhtHelper\General\Helper_Array::isKeyExist($varUserSession, 'environment', $varData)) {
+                                        $varReturn['environment'] = $varData['environment'];
+                                        }
+
+                                    //---> Hitung TTL dari SessionAutoFinishDateTimeTZ (fallback ke session.lifetime config)
+                                    $varTTL = null;
+                                    if (!empty($varData['sessionAutoFinishDateTimeTZ']))
+                                        {
+                                        $varExpiryTS = strtotime($varData['sessionAutoFinishDateTimeTZ']);
+                                        if ($varExpiryTS !== false && $varExpiryTS > time())
+                                            {
+                                            $varTTL = $varExpiryTS - time();
+                                            }
+                                        }
+                                    if ($varTTL === null || $varTTL <= 0)
+                                        {
+                                        $varTTL = ((int) config('session.lifetime', 120)) * 60;
+                                        }
+
+                                    //---> Write-Back ke Redis sehingga request berikutnya hit cache
+                                    \App\Helpers\ZhtHelper\Cache\Helper_Redis::setValue(
+                                        $varUserSession,
+                                        $varRedisKey,
+                                        \App\Helpers\ZhtHelper\General\Helper_Encode::getJSONEncode(
+                                            $varUserSession,
+                                            $varData
+                                            ),
+                                        $varTTL
+                                        );
+                                    }
+                                }
+                            }
+                        catch (\Exception $ex) {
+                            //---> Rehydration gagal : biarkan request berlanjut dengan varReturn kosong
+                            //---> Caller (middleware) akan menolak request bila userLoginSessionID null
                             }
                         }
-                    */
-/*
-//------------< BLOCKING >------------------
-    dd (
-        \App\Helpers\ZhtHelper\General\Helper_DateTime::getDateTimeStringWithTimeZoneDifferenceInterval(
-            \App\Helpers\ZhtHelper\System\Helper_Environment::getUserSessionID_System(),
-            \App\Helpers\ZhtHelper\General\Helper_DateTime::getTimeStampTZConvert_PHPDateTimeToDateTimeTZString(\App\Helpers\ZhtHelper\System\Helper_Environment::getUserSessionID_System(), $varAPIExecutionStartDateTime),
-            \App\Helpers\ZhtHelper\General\Helper_DateTime::getTimeStampTZConvert_PHPDateTimeToDateTimeTZString(\App\Helpers\ZhtHelper\System\Helper_Environment::getUserSessionID_System(), (new \DateTime())),
-            )
-        );
-//------------< BLOCKING >------------------
-*/
                     }
                 }
 


### PR DESCRIPTION
## Summary

- Collapse the per-request Redis round-trips on the hot auth path from **2 → 1** (`isExpired` + `getValue` → single `getValue`).
- Activate cache-miss rehydration: on a Redis miss for a valid live token, fetch the session row from `SchSysConfig.TblLog_UserLoginSession`, repopulate `ERPReborn::APIWebToken::<token>` with a TTL derived from `sessionAutoFinishDateTimeTZ`, and return the same entity shape as the cache-hit branch.
- Remove the dead `/* ... */` block holding the obsolete else branch and the commented `dd()` blocking-profiler scaffold inside `getUserLoginSessionEntityByAPIWebToken`.

## Why

`Helper_API::getUserLoginSessionEntityByAPIWebToken` runs on every authenticated API call. Before this change:

1. **Hit path** issued `Helper_Redis::isExpired` followed by `Helper_Redis::getValue` — two Redis commands per request to do work a single `GET` already covers.
2. **Miss path** verified the token via `isExist_APIWebToken` (one PostgreSQL round-trip) but never wrote the payload back to Redis. If Redis evicted a live token (memory pressure, TTL expiry, Redis restart, failover), every subsequent request fell through to PostgreSQL until the user re-logged in. The fallback `else` branch that would have repopulated Redis was commented out in the original implementation.

After this change the warm path is 1 Redis `GET` per request, and a Redis miss self-heals on the next request rather than degrading silently into a per-request DB round-trip.

## How the rehydration works

On cache miss with a valid token (excluding the SysEngine token, which keeps its existing branch):

1. Pull the row from `SchSysConfig.TblLog_UserLoginSession` filtered by `\"APIWebToken\" = '<token>'` using the existing `DefaultClassPrototype::getAllFilteredDataRecord` helper — no new stored procedure.
2. Decode the `OptionsList` JSON column. This is the exact payload written to Redis at login by `setLogin` / `setLoginBranchAndUserRole` (`userLoginSession_RefID`, `user_RefID`, `userRole_RefID`, `branch_RefID`, `sessionStart/Auto*DateTimeTZ`, `userIdentities`, `environment`).
3. Populate the return entity from the decoded payload, including the existing `getUserIdentity` lookup (itself already cached via Laravel `Cache::remember`).
4. Derive a TTL by subtracting `time()` from `strtotime(sessionAutoFinishDateTimeTZ)`. If the column is missing or already in the past, fall back to `config('session.lifetime', 120) * 60` seconds.
5. Re-`setValue` under `ERPReborn::APIWebToken::<token>` so subsequent requests hit Redis.

Rehydration is wrapped in a defensive `try/catch`; if anything fails (DB unavailable, schema drift, malformed `OptionsList`) the request continues with an unpopulated entity and the auth middleware rejects it the same way it would today.

## Compatibility

- Return shape is unchanged for both hit and miss paths.
- SysEngine token branch is preserved verbatim.
- `getUserIdentity` semantics unchanged (still hits Laravel cache, still adaptive to DB updates).
- `Helper_Redis::getValue` already returns `null` on miss and on Redis unavailability, so collapsing the TTL probe does not change behavior when Redis itself is down — both the old and new code fall through to the DB branch.

## Test plan

- [ ] **Cold hit** — log in, make a `transaction.read.*` call, confirm response succeeds and only one Redis `GET` shows up in the Redis MONITOR output for the auth resolve.
- [ ] **Warm hit** — repeat call within TTL, confirm no PostgreSQL query against `TblLog_UserLoginSession` is issued.
- [ ] **Miss + rehydrate** — `DEL ERPReborn::APIWebToken::<token>` in Redis on a live session, issue a request, confirm:
  - The request succeeds with the same response as a cache hit.
  - A `SELECT ... FROM \"SchSysConfig\".\"TblLog_UserLoginSession\" WHERE \"APIWebToken\" = ...` query is observed in PostgreSQL logs.
  - The Redis key is repopulated (`EXISTS` returns 1, `TTL` returns a positive value).
  - The next request issues no DB query.
- [ ] **Expired session** — let `sessionAutoFinishDateTimeTZ` pass and `DEL` the Redis key, confirm the rehydration TTL falls back to `session.lifetime` rather than producing a negative/zero TTL.
- [ ] **SysEngine token** — confirm the internal SysEngine call path still resolves with `userLoginSessionID = getUserSessionID_System()` and `branchID = 11000000000001`.
- [ ] **Redis down** — stop Redis, confirm requests still resolve via the DB-fallback path (no rehydration write attempted, no exceptions surface to the caller).
- [ ] **Invalid token** — request with an unknown token, confirm `isExist_APIWebToken` returns false, no write-back happens, and the middleware rejects the request.

## Follow-ups (not in this PR)

- `Helper_Environment::getUserSessionID_ByAPIWebToken` (lines 860–905) has the same 2-call `isExpired` + `getValue` pattern. Worth collapsing in a follow-up.
- `setLoginBranchAndUserRole` uses the same key but issues its own `isExist` + `isExpired` + `getValue` triple — also collapsible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)