### PR TITLE
perf(logger): gate Helper_SystemLog trace wrappers behind SYSLOG_TRACE_ENABLED env

### DIFF
--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/Logger/Helper_SystemLog.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/Logger/Helper_SystemLog.php
@@ -31,6 +31,7 @@ namespace App\Helpers\ZhtHelper\Logger
         private static $varDataLogOutputMaxSize;
         private static $varDataLogErrorIndentantionTab;
         private static $varDataLogOutputIndentantionTab;
+        private static $varTraceEnabled = null;
 
 
         /*
@@ -96,6 +97,27 @@ namespace App\Helpers\ZhtHelper\Logger
             }
 
 
+        /*
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Method Name     : isTraceEnabled                                                                                       |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Description     : Cek apakah trace logging aktif. Default OFF. Hidupkan via env SYSLOG_TRACE_ENABLED=true.            |
+        |                     Hasil di-memoize untuk seumur hidup proses agar overhead pengecekan env minimal.                     |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Output Variable :                                                                                                      |
+        |      ▪ (bool) varReturn                                                                                                  |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        */
+        private static function isTraceEnabled()
+            {
+            if (self::$varTraceEnabled === null)
+                {
+                self::$varTraceEnabled = filter_var(env('SYSLOG_TRACE_ENABLED', false), FILTER_VALIDATE_BOOLEAN);
+                }
+            return self::$varTraceEnabled;
+            }
+
+
         private static function getCurrentOutputIndentation($varUserSession)
             {
             self::setAutoInit();
@@ -115,6 +137,18 @@ namespace App\Helpers\ZhtHelper\Logger
             
         public static function setLogOutputMethodProcessHeader($varUserSession, $varClassName, $varMethodName, $varCustomMessage=null)
             {
+            if (!self::isTraceEnabled())
+                {
+                return [
+                    'ClassName'            => $varClassName,
+                    'MethodName'           => $varMethodName,
+                    'Message'              => $varCustomMessage,
+                    'LogOutputIndentation' => 0,
+                    'Status'               => null,
+                    'StatusMessage'        => null,
+                    ];
+                }
+
             self::setAutoInit();
 
             $varData['ClassName'] = $varClassName;
@@ -129,6 +163,13 @@ namespace App\Helpers\ZhtHelper\Logger
 
         public static function setLogOutputMethodProcessStatus($varUserSession, &$varData, $varStatus, $varCustomMessage=null)
             {
+            if (!self::isTraceEnabled())
+                {
+                $varData['Status'] = $varStatus;
+                $varData['StatusMessage'] = $varCustomMessage;
+                return;
+                }
+
             self::setAutoInit();
 
             $varData['Status'] = $varStatus;
@@ -138,6 +179,11 @@ namespace App\Helpers\ZhtHelper\Logger
 
         public static function setLogOutputMethodProcessFooter($varUserSession, &$varData)
             {
+            if (!self::isTraceEnabled())
+                {
+                return;
+                }
+
             self::setAutoInit();
 
             $varDataSession = \App\Helpers\ZhtHelper\General\Helper_Session::get(\App\Helpers\ZhtHelper\System\Helper_Environment::getApplicationID());
@@ -185,6 +231,11 @@ namespace App\Helpers\ZhtHelper\Logger
 
         public static function setLogOutputMethodHeader($varUserSession, $varReturnInitialValue, $varClassName, $varMethodName, $varCustomMessage=null)
             {
+            if (!self::isTraceEnabled())
+                {
+                return $varReturnInitialValue;
+                }
+
             \App\Helpers\ZhtHelper\Logger\Helper_SystemLog::setLogIndentationIncrease($varUserSession);
             \App\Helpers\ZhtHelper\Logger\Helper_SystemLog::setLogOutput($varUserSession, $varClassName, '('.$varMethodName.') '.($varCustomMessage ? $varCustomMessage : 'Entry Point'));
             return $varReturnInitialValue;
@@ -192,6 +243,11 @@ namespace App\Helpers\ZhtHelper\Logger
 
         public static function setLogOutputMethodFooter($varUserSession, &$varReturn, $varClassName, $varMethodName, $varCustomMessage=null)
             {
+            if (!self::isTraceEnabled())
+                {
+                return $varReturn;
+                }
+
             $varDataSession =
                 \App\Helpers\ZhtHelper\General\Helper_Session::get(
                     \App\Helpers\ZhtHelper\System\Helper_Environment::getApplicationID()
@@ -358,6 +414,11 @@ namespace App\Helpers\ZhtHelper\Logger
         */
         public static function setLastLogOuputAppend($varUserSession, $varMessage=null)
             {
+            if (!self::isTraceEnabled())
+                {
+                return;
+                }
+
             $varDataSession = \App\Helpers\ZhtHelper\General\Helper_Session::get(\App\Helpers\ZhtHelper\System\Helper_Environment::getApplicationID());
             $varData=$varDataSession['Log']['Specific'][$varUserSession]['Output'][count($varDataSession['Log']['Specific'][$varUserSession]['Output'])-1];
             $varDataSession['Log']['Specific'][$varUserSession]['Output'][count($varDataSession['Log']['Specific'][$varUserSession]['Output'])-1] = substr($varData, 0, strlen($varData)-1).' ► '.$varMessage.']';
@@ -385,6 +446,11 @@ namespace App\Helpers\ZhtHelper\Logger
         */
         public static function setLogError($varUserSession, $varCallerID, $varMessage=null)
             {
+            if (!self::isTraceEnabled())
+                {
+                return;
+                }
+
             self::setAutoInit();
 
             $varDataSession = \App\Helpers\ZhtHelper\General\Helper_Session::get(\App\Helpers\ZhtHelper\System\Helper_Environment::getApplicationID());
@@ -425,6 +491,11 @@ namespace App\Helpers\ZhtHelper\Logger
         */
         public static function setLogOutput($varUserSession, $varCallerID, $varMessage=null)
             {
+            if (!self::isTraceEnabled())
+                {
+                return;
+                }
+
             self::setAutoInit();
 
             $varDataSession = \App\Helpers\ZhtHelper\General\Helper_Session::get(\App\Helpers\ZhtHelper\System\Helper_Environment::getApplicationID());
@@ -461,6 +532,11 @@ namespace App\Helpers\ZhtHelper\Logger
         */
         public static function setLogIndentationIncrease($varUserSession)
             {
+            if (!self::isTraceEnabled())
+                {
+                return;
+                }
+
             self::setAutoInit();
             self::init();
 
@@ -493,8 +569,13 @@ namespace App\Helpers\ZhtHelper\Logger
         */
         public static function setLogIndentationDecrease($varUserSession)
             {
+            if (!self::isTraceEnabled())
+                {
+                return;
+                }
+
             self::setAutoInit();
-            
+
             $varDataSession = \App\Helpers\ZhtHelper\General\Helper_Session::get(\App\Helpers\ZhtHelper\System\Helper_Environment::getApplicationID());
             $varOutputIndentation = \App\Helpers\ZhtHelper\General\Helper_Array::getArrayValue($varDataSession, 'Log::Specific::'.$varUserSession.'::OutputIndentation') - self::$varDataLogOutputIndentantionTab;
             \App\Helpers\ZhtHelper\General\Helper_Array::setArrayValue($varDataSession, 'Log::Specific::'.$varUserSession.'::OutputIndentation', $varOutputIndentation);            


### PR DESCRIPTION
## Summary

- Make the `Helper_SystemLog` trace pipeline opt-in. Default OFF.
- Add `SYSLOG_TRACE_ENABLED` env flag (memoized at first read).
- Short-circuit all 10 public mutators when tracing is disabled.
- Preserve all return contracts so the ~10,286 call sites across helpers/models/engines need zero changes.

## Why

`Helper_SystemLog::setLogOutputMethod*` wraps every method body in the codebase with a 5-call sequence:

```
setLogOutputMethodHeader(...)             // entry
setLogOutputMethodProcessHeader(...)      // sub-process entry
// ...work...
setLogOutputMethodProcessStatus(...)      // status mutation
setLogOutputMethodProcessFooter(...)      // sub-process exit
setLogOutputMethodFooter(...)             // exit
```

`grep` confirms **10,286 call sites**. Each wrap performs at least one `Helper_Session::get(applicationID)` followed by `Helper_Session::set(applicationID, ...)`, both of which (de)serialize the full session blob. For a typical authenticated read endpoint that walks hundreds of helper methods in its call tree, this means **500-2,000 session read/write cycles per request**, on the hot path, just to populate an in-session HTML debug buffer that production never consumes.

The buffer is bounded at 100 entries (`array_shift` on overflow), HTML-encoded with `&nbsp;` indentation, and is only ever rendered by `getLogOutput()` — a sandbox/debug UI helper. Production sessions still pay the cost (CPU, memory, session-store I/O) every request and grow the session payload, defeating Laravel's lazy session write.

## How

- New `private static $varTraceEnabled = null` property.
- New `private static isTraceEnabled()` reads `env('SYSLOG_TRACE_ENABLED', false)` once via `FILTER_VALIDATE_BOOLEAN`, memoizes the result for the process lifetime.
- Every public mutator early-returns when `!isTraceEnabled()`:
  - `setLogOutputMethodHeader` returns `$varReturnInitialValue` unchanged.
  - `setLogOutputMethodFooter` returns `$varReturn` unchanged.
  - `setLogOutputMethodProcessHeader` returns an associative array with the same keys (`ClassName`, `MethodName`, `Message`, `LogOutputIndentation`, `Status`, `StatusMessage`) so callers can still pass it to `Status` / `Footer`.
  - `setLogOutputMethodProcessStatus` still mutates `&$varData['Status']` / `['StatusMessage']` so callers that read those fields after the call keep working.
  - `setLogOutputMethodProcessFooter`, `setLogOutput`, `setLogError`, `setLastLogOuputAppend`, `setLogIndentationIncrease`, `setLogIndentationDecrease` all become no-ops.
- `getLogOutput` / `getLogError` (dev consumers) untouched — they still render the buffer if tracing happens to be enabled.

## Compatibility

- Zero changes required at call sites.
- Behavior unchanged when `SYSLOG_TRACE_ENABLED=true`.
- When OFF (default): same return types, same `&$varData` mutations for status fields, no session writes.

## Test plan

- [ ] **Default (env unset)** — hit a `transaction.read.*` engine. Confirm response unchanged. Inspect session storage: no `Log::Specific::*` keys written. Latency drop measurable on read-heavy endpoints.
- [ ] **Enabled (`SYSLOG_TRACE_ENABLED=true`)** — hit `getLogOutput` in the sandbox. Confirm the HTML table renders with the expected nested indentation, entry/exit lines, and sub-process status markers — identical to current behavior.
- [ ] **Toggle at runtime** — first request with flag OFF, then `SYSLOG_TRACE_ENABLED=true` in `.env` + cache clear, second request renders trace. (Memoization is per-process; PHP-FPM/Octane workers pick up the change after restart.)
- [ ] **Return-shape regression** — exercise an engine that consumes `setLogOutputMethodProcessHeader`'s result (e.g. any read-list engine). Confirm no `Undefined index` warnings for `ClassName`/`MethodName`/`Message`/`LogOutputIndentation`/`Status`/`StatusMessage` when flag is OFF.
- [ ] **Error path** — force an exception inside a helper. Confirm the outer `try/catch` still surfaces the error without depending on trace state.
- [ ] **Octane / FrankenPHP** — verify `$varTraceEnabled` memoization survives across requests in the same worker (intended), and that flipping the env requires a worker restart (documented).

## Follow-up (separate PRs)

- Stack #2 — finish Loki migration, drop `TblRotateLog_API` dual-write.
- Stack #4 — fix `TblRotateLog_FailedUserLogin` cross-wire to API proc (already flagged).
- Stack #5 — Loki migration for `TblRotateLog_APIRequestByGet_Signature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)