### PR TITLE
feat(observability): per-request DB query latency profiler emitted to Loki

### DIFF
--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
@@ -216,7 +216,15 @@ namespace App\Helpers\ZhtHelper\Database
                             */
 
                             pg_last_notice($DBConnection, PGSQL_NOTICE_CLEAR);
+                            $varProfilerStartNs = hrtime(true);
                             $varResult = pg_query($DBConnection, $varSQLQuery);
+                            \App\Helpers\ZhtHelper\Logger\Helper_QueryProfiler::record(
+                                'pgsql',
+                                $varSQLQuery,
+                                (hrtime(true) - $varProfilerStartNs) / 1e6,
+                                ($varResult !== false),
+                                ($varResult === false ? pg_last_error($DBConnection) : null)
+                                );
                             $varNotice = pg_last_notice($DBConnection, PGSQL_NOTICE_ALL);
 
                             /*
@@ -1071,8 +1079,28 @@ namespace App\Helpers\ZhtHelper\Database
                     //---- ( MAIN CODE ) --------------------------------------------------------------------- [ START POINT ] -----
                     //$varSQLQuery = preg_replace('/\s+/', '', $varSQLQuery);
                     $varSQLQuery = ltrim(str_replace("\n", "" , $varSQLQuery));
-                    
-                    $varReturn = \Illuminate\Support\Facades\DB::select($varSQLQuery);
+
+                    $varProfilerStartNs = hrtime(true);
+                    try {
+                        $varReturn = \Illuminate\Support\Facades\DB::select($varSQLQuery);
+                        \App\Helpers\ZhtHelper\Logger\Helper_QueryProfiler::record(
+                            'laravel',
+                            $varSQLQuery,
+                            (hrtime(true) - $varProfilerStartNs) / 1e6,
+                            true,
+                            null
+                            );
+                        }
+                    catch (\Throwable $varProfilerEx) {
+                        \App\Helpers\ZhtHelper\Logger\Helper_QueryProfiler::record(
+                            'laravel',
+                            $varSQLQuery,
+                            (hrtime(true) - $varProfilerStartNs) / 1e6,
+                            false,
+                            $varProfilerEx->getMessage()
+                            );
+                        throw $varProfilerEx;
+                        }
                     
                     //dd(((array) \Illuminate\Support\Facades\DB::getConnections())['pgsql']);
                     //$connection = \Illuminate\Support\Facades\DB::connection();

--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/Logger/Helper_QueryProfiler.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/Logger/Helper_QueryProfiler.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
++----------------------------------------------------------------------------------------------------------------------------------+
+| ▪ Category   : Laravel Helpers                                                                                                   |
+| ▪ Name Space : \App\Helpers\ZhtHelper\Logger                                                                                     |
+|                                                                                                                                  |
+| ▪ Description : Request-scoped database query profiler. Captures duration of each DB call made through Helper_PostgreSQL          |
+|                 (both Laravel-facade and raw pg_* paths) and exposes an aggregated snapshot for the audit/Loki sink in the        |
+|                 terminate middleware.                                                                                             |
++----------------------------------------------------------------------------------------------------------------------------------+
+*/
+
+namespace App\Helpers\ZhtHelper\Logger
+    {
+
+    class Helper_QueryProfiler
+        {
+        /*
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | Class Properties                                                                                                         |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        */
+        private static $varEnabled       = null;
+        private static $varCaptureSQL    = null;
+        private static $varMaxSQLLength  = null;
+        private static $varMaxEntries    = null;
+        private static $varEntries       = [];
+        private static $varTotalCount    = 0;
+        private static $varTotalDuration = 0.0;
+
+
+        /*
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Method Name     : isEnabled                                                                                            |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Description     : Cek apakah profiler aktif. Memoized ke property statik untuk seumur hidup proses.                    |
+        |                     Default ON. Matikan via env DB_QUERY_PROFILER_ENABLED=false.                                          |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Output Variable :                                                                                                      |
+        |      ▪ (bool) varReturn                                                                                                  |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        */
+        public static function isEnabled()
+            {
+            if (self::$varEnabled === null)
+                {
+                self::$varEnabled       = filter_var(env('DB_QUERY_PROFILER_ENABLED', true), FILTER_VALIDATE_BOOLEAN);
+                self::$varCaptureSQL    = filter_var(env('DB_QUERY_PROFILER_CAPTURE_SQL', true), FILTER_VALIDATE_BOOLEAN);
+                self::$varMaxSQLLength  = (int) env('DB_QUERY_PROFILER_SQL_MAX_LENGTH', 4096);
+                self::$varMaxEntries    = (int) env('DB_QUERY_PROFILER_MAX_ENTRIES', 500);
+                }
+
+            return self::$varEnabled;
+            }
+
+
+        /*
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Method Name     : record                                                                                               |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Description     : Catat satu eksekusi query ke buffer request-scoped.                                                   |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Input Variable  :                                                                                                      |
+        |      ▪ (string) varSource ► Origin tag (pgsql|laravel)                                                                   |
+        |      ▪ (string) varSQL ► Query text (boleh kosong bila capture sql dimatikan)                                            |
+        |      ▪ (float)  varDurationMs ► Durasi eksekusi dalam milidetik                                                          |
+        |      ▪ (bool)   varSuccess ► Status sukses                                                                                |
+        |      ▪ (string) varError ► Pesan error opsional                                                                          |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        */
+        public static function record($varSource, $varSQL, $varDurationMs, $varSuccess = true, $varError = null)
+            {
+            if (!self::isEnabled())
+                {
+                return;
+                }
+
+            self::$varTotalCount++;
+            self::$varTotalDuration += $varDurationMs;
+
+            //---> Bounded buffer. Drop oldest entries once cap reached (still counted in totals).
+            if (count(self::$varEntries) >= self::$varMaxEntries)
+                {
+                array_shift(self::$varEntries);
+                }
+
+            $varSQLTrimmed = null;
+            if (self::$varCaptureSQL && $varSQL !== null)
+                {
+                $varSQLTrimmed = preg_replace('/\s+/', ' ', trim((string) $varSQL));
+                if (self::$varMaxSQLLength > 0 && strlen($varSQLTrimmed) > self::$varMaxSQLLength)
+                    {
+                    $varSQLTrimmed = substr($varSQLTrimmed, 0, self::$varMaxSQLLength).'…';
+                    }
+                }
+
+            self::$varEntries[] = [
+                'source'      => $varSource,
+                'sql'         => $varSQLTrimmed,
+                'duration_ms' => round((float) $varDurationMs, 3),
+                'success'     => (bool) $varSuccess,
+                'error'       => $varError,
+                ];
+            }
+
+
+        /*
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Method Name     : getSnapshot                                                                                          |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Description     : Kembalikan aggregated snapshot untuk emit ke Loki.                                                   |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Output Variable :                                                                                                      |
+        |      ▪ (array) varReturn                                                                                                 |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        */
+        public static function getSnapshot()
+            {
+            $varCount       = self::$varTotalCount;
+            $varDurations   = array_column(self::$varEntries, 'duration_ms');
+            $varBufferedMax = (count($varDurations) > 0) ? max($varDurations) : 0.0;
+            $varBufferedMin = (count($varDurations) > 0) ? min($varDurations) : 0.0;
+
+            return [
+                'enabled'           => self::isEnabled(),
+                'total_count'       => $varCount,
+                'total_duration_ms' => round(self::$varTotalDuration, 3),
+                'avg_duration_ms'   => $varCount > 0 ? round(self::$varTotalDuration / $varCount, 3) : 0.0,
+                'buffered_entries'  => count(self::$varEntries),
+                'buffered_max_ms'   => round($varBufferedMax, 3),
+                'buffered_min_ms'   => round($varBufferedMin, 3),
+                'queries'           => self::$varEntries,
+                ];
+            }
+
+
+        /*
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Method Name     : reset                                                                                                |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        | ▪ Description     : Kosongkan buffer. Wajib dipanggil di awal setiap request bila berjalan di worker yang reuse           |
+        |                     proses (Laravel Octane / FrankenPHP).                                                                 |
+        +--------------------------------------------------------------------------------------------------------------------------+
+        */
+        public static function reset()
+            {
+            self::$varEntries       = [];
+            self::$varTotalCount    = 0;
+            self::$varTotalDuration = 0.0;
+            }
+        }
+    }

--- a/Programming/.LaravelCore/app/Http/Middleware/Application/BackEnd/API/Authentication/TerminateHandler.php
+++ b/Programming/.LaravelCore/app/Http/Middleware/Application/BackEnd/API/Authentication/TerminateHandler.php
@@ -56,6 +56,8 @@ namespace App\Http\Middleware\Application\BackEnd\API\Authentication
                     );
                 }
 
+            $varDBProfile = \App\Helpers\ZhtHelper\Logger\Helper_QueryProfiler::getSnapshot();
+
             if ($varWriteLoki)
                 {
                 try
@@ -74,6 +76,7 @@ namespace App\Http\Middleware\Application\BackEnd\API\Authentication
                         'response_status'  => $varResponseStatus,
                         'response_headers' => $varResponseHeaders,
                         'response_body'    => $varResponseBody,
+                        'db_profile'       => $varDBProfile,
                     ]);
                     }
                 catch (\Throwable $e)
@@ -84,6 +87,9 @@ namespace App\Http\Middleware\Application\BackEnd\API\Authentication
                         );
                     }
                 }
+
+            //---> Wajib reset terakhir agar worker yang dipakai ulang (Octane/FrankenPHP) tidak membawa state request sebelumnya.
+            \App\Helpers\ZhtHelper\Logger\Helper_QueryProfiler::reset();
             }
         }
     }

--- a/Programming/.LaravelCore/app/Http/Middleware/Application/BackEnd/API/Gateway/TerminateHandler.php
+++ b/Programming/.LaravelCore/app/Http/Middleware/Application/BackEnd/API/Gateway/TerminateHandler.php
@@ -56,6 +56,8 @@ namespace App\Http\Middleware\Application\BackEnd\API\Gateway
                     );
                 }
 
+            $varDBProfile = \App\Helpers\ZhtHelper\Logger\Helper_QueryProfiler::getSnapshot();
+
             if ($varWriteLoki)
                 {
                 try
@@ -74,6 +76,7 @@ namespace App\Http\Middleware\Application\BackEnd\API\Gateway
                         'response_status'  => $varResponseStatus,
                         'response_headers' => $varResponseHeaders,
                         'response_body'    => $varResponseBody,
+                        'db_profile'       => $varDBProfile,
                     ]);
                     }
                 catch (\Throwable $e)
@@ -84,6 +87,9 @@ namespace App\Http\Middleware\Application\BackEnd\API\Gateway
                         );
                     }
                 }
+
+            //---> Wajib reset terakhir agar worker yang dipakai ulang (Octane/FrankenPHP) tidak membawa state request sebelumnya.
+            \App\Helpers\ZhtHelper\Logger\Helper_QueryProfiler::reset();
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `Helper_QueryProfiler`: request-scoped buffer that records every DB call routed through `Helper_PostgreSQL` (both raw `pg_query` and Laravel `DB::select` paths) with `hrtime`-based latency.
- Surface an aggregated `db_profile` block inside the existing `audit_api` Loki record emitted by both `TerminateHandler` middlewares (Authentication + Gateway).
- Env-driven config; sane defaults; no call-site changes; bounded buffer so it does not blow up large requests.

## Why

The codebase already dual-writes the API audit trail (Postgres `TblRotateLog_API` + Loki via `audit_api` channel). What's missing is **DB latency per request** — total query count, total time spent in the database, slowest call, and (optionally) the SQL list. With Loki already in place, this can land as a single new field on the existing log line; no new sink, no new ingestion path, no new index.

## How

### `Helper_QueryProfiler` (new)

`app/Helpers/ZhtHelper/Logger/Helper_QueryProfiler.php`

- Static class. Internal state: `varEntries[]`, `varTotalCount`, `varTotalDuration`.
- `isEnabled()` lazily reads four env knobs (memoized for the process):
  - `DB_QUERY_PROFILER_ENABLED` (default `true`)
  - `DB_QUERY_PROFILER_CAPTURE_SQL` (default `true`)
  - `DB_QUERY_PROFILER_SQL_MAX_LENGTH` (default `4096`)
  - `DB_QUERY_PROFILER_MAX_ENTRIES` (default `500`)
- `record($source, $sql, $durationMs, $success, $error)`:
  - Skips early when disabled.
  - Bumps `total_count` + `total_duration`.
  - Bounded ring buffer: once `MAX_ENTRIES` is hit, oldest entries are dropped (totals still reflect every call).
  - SQL text is whitespace-normalized and truncated to `SQL_MAX_LENGTH` before storage.
- `getSnapshot()` returns `{enabled, total_count, total_duration_ms, avg_duration_ms, buffered_entries, buffered_max_ms, buffered_min_ms, queries[]}`.
- `reset()` clears state — invoked after every Loki emit so Octane / FrankenPHP workers don't bleed state across requests.

### Instrumentation in `Helper_PostgreSQL`

Two physical query call sites exist:

1. `getArrayFromQueryExecutionDataFetch_UsingPGSQLConnection` (raw `pg_query`):
   ```php
   $varProfilerStartNs = hrtime(true);
   $varResult = pg_query($DBConnection, $varSQLQuery);
   Helper_QueryProfiler::record(
       'pgsql',
       $varSQLQuery,
       (hrtime(true) - $varProfilerStartNs) / 1e6,
       ($varResult !== false),
       ($varResult === false ? pg_last_error($DBConnection) : null)
   );
   ```

2. `getQueryExecutionDataFetch` (Laravel facade path):
   ```php
   $varProfilerStartNs = hrtime(true);
   try {
       $varReturn = DB::select($varSQLQuery);
       Helper_QueryProfiler::record('laravel', $varSQLQuery, ..., true, null);
   } catch (\Throwable $varProfilerEx) {
       Helper_QueryProfiler::record('laravel', $varSQLQuery, ..., false, $varProfilerEx->getMessage());
       throw $varProfilerEx;
   }
   ```

Both backends (`WebBackEnd`, `WebBackEnd_LaravelOctane_FrankenPHP`) symlink `ZhtHelper` into `.LaravelCore`, so a single edit covers both.

### Loki emit + reset in `TerminateHandler`

Both `Authentication/TerminateHandler.php` and `Gateway/TerminateHandler.php`:

- Snapshot the profiler immediately after the audit fields are gathered.
- When the audit driver includes `loki`, add `'db_profile' => $varDBProfile` to the existing `Log::channel('audit_api')->info('api_access', [...])` payload.
- Call `Helper_QueryProfiler::reset()` at the end of `terminate()` so the next request on a reused worker starts fresh.

## Payload shape (added under `db_profile`)

```json
{
  "enabled":           true,
  "total_count":       17,
  "total_duration_ms": 142.318,
  "avg_duration_ms":   8.371,
  "buffered_entries":  17,
  "buffered_max_ms":   53.119,
  "buffered_min_ms":   0.214,
  "queries": [
    {"source": "pgsql",   "sql": "SELECT ...", "duration_ms": 12.345, "success": true,  "error": null},
    {"source": "laravel", "sql": "SELECT NOW();", "duration_ms": 0.812, "success": true,  "error": null}
  ]
}
```

## Compatibility

- Zero call-site changes required.
- No new dependencies, no new Laravel service providers.
- `Helper_PostgreSQL` return shapes unchanged.
- Loki payload only gains a new `db_profile` key — Grafana / Loki labels untouched, dashboards built on existing labels keep working.
- Profiler can be cut at any time with `DB_QUERY_PROFILER_ENABLED=false`.

## Test plan

- [ ] **Profiler ON, default config**: hit `transaction.read.dataList.supplyChain.getSupplierList`, observe `audit_api` Loki entry with `db_profile.total_count > 0`, durations matching `EXPLAIN ANALYZE` ballpark.
- [ ] **SQL capture OFF (`DB_QUERY_PROFILER_CAPTURE_SQL=false`)**: confirm `queries[].sql` is `null`, totals still populated.
- [ ] **Long SQL truncation**: send a query longer than `DB_QUERY_PROFILER_SQL_MAX_LENGTH`. Confirm trailing `…` and length cap.
- [ ] **Ring buffer overflow**: synthesize >500 queries in a single request (e.g. a heavy batch endpoint), confirm `buffered_entries == 500`, `total_count` reflects the real count, oldest entries are dropped.
- [ ] **Failing query**: force a syntax error via `DB::select` and via `pg_query`. Confirm `success=false`, `error` populated, exception still propagates to the caller for `DB::select` path.
- [ ] **Octane / FrankenPHP**: run two consecutive requests on the same worker. Confirm second request's snapshot is independent of the first (reset works).
- [ ] **Profiler OFF**: set `DB_QUERY_PROFILER_ENABLED=false`. Confirm `db_profile.enabled == false`, `total_count == 0`, `queries == []`. No latency overhead beyond the env read.
- [ ] **Audit driver `db` only**: set `AUDIT_LOG_DRIVER=db`. Confirm no Loki emit, no exception from missing `db_profile` (since the field is only added inside the Loki branch).
- [ ] **Audit driver `loki` only**: set `AUDIT_LOG_DRIVER=loki`. Confirm DB audit insert is skipped, Loki record carries `db_profile`.

## Follow-ups (separate PRs)

- Remove the two `SELECT NOW();` round-trips inside `Helper_PostgreSQL::getQueryExecution` that currently measure timing at the DBMS — the new profiler already captures the same data via `hrtime`, so those queries can be dropped (saves ~2 DB roundtrips per stored-proc call).
- Tag the Loki record with `loki_labels` for `phase`, `response_status`, and `db_total_count_bucket` so PromQL/LogQL queries can slice by latency band without parsing JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)