### PR TITLE
fix(audit): flush LokiHandler per request so audit_api lines reach Loki under Octane

### DIFF
--- a/Programming/.LaravelCore/app/Http/Middleware/Application/BackEnd/API/Authentication/TerminateHandler.php
+++ b/Programming/.LaravelCore/app/Http/Middleware/Application/BackEnd/API/Authentication/TerminateHandler.php
@@ -78,6 +78,17 @@ namespace App\Http\Middleware\Application\BackEnd\API\Authentication
                         'response_body'    => $varResponseBody,
                         'db_profile'       => $varDBProfile,
                     ]);
+
+                    //---> Flush eksplisit per request. Wajib karena LokiHandler buffer via
+                    //     register_shutdown_function, yang di Octane/FrankenPHP worker hanya fire saat
+                    //     worker exit (bukan per request). Tanpa flush ini buffer tidak pernah dikirim.
+                    foreach (\Illuminate\Support\Facades\Log::channel('audit_api')->getLogger()->getHandlers() as $varLokiHandler)
+                        {
+                        if ($varLokiHandler instanceof \App\Logging\LokiHandler)
+                            {
+                            $varLokiHandler->flush();
+                            }
+                        }
                     }
                 catch (\Throwable $e)
                     {

--- a/Programming/.LaravelCore/app/Http/Middleware/Application/BackEnd/API/Gateway/TerminateHandler.php
+++ b/Programming/.LaravelCore/app/Http/Middleware/Application/BackEnd/API/Gateway/TerminateHandler.php
@@ -78,6 +78,17 @@ namespace App\Http\Middleware\Application\BackEnd\API\Gateway
                         'response_body'    => $varResponseBody,
                         'db_profile'       => $varDBProfile,
                     ]);
+
+                    //---> Flush eksplisit per request. Wajib karena LokiHandler buffer via
+                    //     register_shutdown_function, yang di Octane/FrankenPHP worker hanya fire saat
+                    //     worker exit (bukan per request). Tanpa flush ini buffer tidak pernah dikirim.
+                    foreach (\Illuminate\Support\Facades\Log::channel('audit_api')->getLogger()->getHandlers() as $varLokiHandler)
+                        {
+                        if ($varLokiHandler instanceof \App\Logging\LokiHandler)
+                            {
+                            $varLokiHandler->flush();
+                            }
+                        }
                     }
                 catch (\Throwable $e)
                     {


### PR DESCRIPTION
## Summary

- Force `LokiHandler::flush()` explicitly inside the `try` of both API `TerminateHandler` middlewares (Authentication + Gateway), right after the `Log::channel('audit_api')->info()` call.
- Fixes the symptom that audit lines never appear in Grafana/Loki even though the `Log::info()` call returns normally and Helper_QueryProfiler runs.

## Why

`App\Logging\LokiHandler` buffers writes in `$this->buffer` and flushes via `register_shutdown_function([\$this, 'flush'])`. Under classic PHP-FPM that contract is fine — shutdown functions fire when the per-request worker exits. Under Laravel Octane / FrankenPHP worker mode the PHP process is reused across many requests; `register_shutdown_function` fires only when the worker itself terminates, not at the end of each request. The result is:

- The audit_api buffer accumulates indefinitely.
- Lines (including the new `db_profile` field from `Helper_QueryProfiler`) never reach Loki for live requests.
- The app log looks healthy — no exception, no fallback warning on the `single` channel — because the handler never got a chance to attempt the push.

The repo contains `WebBackEnd_LaravelOctane_FrankenPHP/`, so this is the live shape.

## How

Both terminate middlewares now walk the `audit_api` channel's Monolog handler stack and call `LokiHandler::flush()` after `info()`:

```php
foreach (\Illuminate\Support\Facades\Log::channel('audit_api')->getLogger()->getHandlers() as $varLokiHandler) {
    if ($varLokiHandler instanceof \App\Logging\LokiHandler) {
        $varLokiHandler->flush();
    }
}
```

- Type-guarded so it only touches `LokiHandler` instances; other handlers attached to the same channel are untouched.
- Sits inside the existing `try`/`catch`, so any Loki push failure still surfaces as the existing `'Loki audit emit failed'` warning on the `single` channel — no exception leaks to the response.
- Runs before `Helper_QueryProfiler::reset()` so the snapshot included in the payload is the one that just shipped.

The handler-side `register_shutdown_function` path is left in place as a belt-and-braces flush; explicit flush wins under Octane, shutdown fires under classic FPM.

## Test plan

- [ ] **Classic PHP-FPM** — issue a request, confirm Grafana Explore `{app=\"erp_reborn\"}` shows the JSON line with the expected `db_profile` block within seconds.
- [ ] **Octane / FrankenPHP** — same probe; without this fix the line never arrived, with it the line should arrive at request end.
- [ ] **Loki down** — stop the Loki container, issue a request; expect the request to still succeed and a single \"Loki audit push failed\" / \"Loki audit emit failed\" warning per request in `storage/logs/laravel.log`. No exception in response, no slowdown beyond the configured `LOKI_TIMEOUT`.
- [ ] **Audit driver `db` only** — set `AUDIT_LOG_DRIVER=db`; confirm no Loki push attempted and no warning.
- [ ] **Multiple Octane requests on the same worker** — issue 5 requests, confirm 5 distinct lines (not one batched dump on worker exit).

## Follow-ups (separate)

- Consider raising `LOKI_TIMEOUT` default from `0.25` to `1.0` — current default drops silently if Loki responds slowly.
- Move the flush into `LokiHandler::close()` + a Laravel `Terminating` event hook so terminate middlewares don't need to know about handler internals. The current placement is the minimal-blast-radius fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)