### PR TITLE
feat(logging): add configurable loki channel for general Laravel logs

### DIFF
--- a/Programming/WebBackEnd_LaravelOctane_FrankenPHP/config/logging.php
+++ b/Programming/WebBackEnd_LaravelOctane_FrankenPHP/config/logging.php
@@ -54,8 +54,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            //'channels' => explode(',', (string) env('LOG_STACK', 'single')),
-            'channels' => ['stderr'],
+            'channels' => explode(',', (string) env('LOG_STACK', 'stderr')),
             'ignore_exceptions' => false,
         ],
 
@@ -131,6 +130,22 @@ return [
 
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
+        ],
+
+        'loki' => [
+            'driver'    => 'monolog',
+            'handler'   => \App\Logging\LokiHandler::class,
+            'with'      => [
+                'endpoint' => env('LOKI_PUSH_URL', 'http://grafana-loki:3100/loki/api/v1/push'),
+                'timeout'  => (float) env('LOKI_TIMEOUT', 0.25),
+                'labels'   => [
+                    'app' => 'erp_reborn',
+                    'env' => env('APP_ENV', 'production'),
+                    'job' => 'laravel',
+                ],
+            ],
+            'formatter' => \Monolog\Formatter\JsonFormatter::class,
+            'level'     => env('LOG_LEVEL', 'debug'),
         ],
 
         'audit_api' => [


### PR DESCRIPTION
## Summary
- Add `loki` channel using `LokiHandler` so general Laravel app logs push directly to Grafana Loki
- Stack channels now driven by `LOG_STACK` env var (default: `stderr`) — no behaviour change for prod
- Dev server can set `LOG_STACK=stderr,loki` + `LOKI_PUSH_URL` to get Laravel logs in Grafana without Docker Loki driver

## Root cause fixed
`stack` channel was hardcoded to `['stderr']` only. Dev servers without the Docker Loki plugin had no path for Laravel logs to reach Loki.

## How to activate on dev
```env
LOG_STACK=stderr,loki
LOKI_PUSH_URL=http://172.28.0.111:3100/loki/api/v1/push
```

## Test plan
- [ ] Prod: verify no change — `LOG_STACK` unset, Docker Loki driver still captures stderr
- [ ] Dev: set `LOG_STACK=stderr,loki`, trigger a log entry, confirm it appears in Grafana under `job=laravel`
- [ ] Confirm `audit_api` channel unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)