### PR TITLE
feat(logging): add loki channel and LOG_STACK env to WebBackEnd

### DIFF
--- a/Programming/WebBackEnd/app/Logging/LokiHandler.php
+++ b/Programming/WebBackEnd/app/Logging/LokiHandler.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+class LokiHandler extends AbstractProcessingHandler
+{
+    private array $buffer = [];
+    private string $endpoint;
+    private float $timeout;
+    private array $baseLabels;
+    private bool $shutdownRegistered = false;
+
+    public function __construct(
+        string $endpoint,
+        float $timeout = 0.25,
+        array $labels = [],
+        int|string|Level $level = Level::Debug,
+        bool $bubble = true
+    ) {
+        parent::__construct($level, $bubble);
+        $this->endpoint = $endpoint;
+        $this->timeout = $timeout;
+        $this->baseLabels = $labels;
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        $this->buffer[] = $record->formatted;
+        $this->registerShutdownFlush();
+    }
+
+    private function registerShutdownFlush(): void
+    {
+        if ($this->shutdownRegistered) {
+            return;
+        }
+        $this->shutdownRegistered = true;
+        register_shutdown_function([$this, 'flush']);
+    }
+
+    public function flush(): void
+    {
+        if (empty($this->buffer)) {
+            return;
+        }
+        $items = $this->buffer;
+        $this->buffer = [];
+
+        try {
+            $streams = [];
+            foreach ($items as $item) {
+                if (!is_array($item) || !isset($item['tuple'])) {
+                    continue;
+                }
+                $labels = array_merge($this->baseLabels, $item['labels'] ?? []);
+                ksort($labels);
+                $key = json_encode($labels);
+                if (!isset($streams[$key])) {
+                    $streams[$key] = ['stream' => $labels, 'values' => []];
+                }
+                $streams[$key]['values'][] = $item['tuple'];
+            }
+
+            if (empty($streams)) {
+                return;
+            }
+
+            \Illuminate\Support\Facades\Http::timeout($this->timeout)
+                ->withHeaders(['Content-Type' => 'application/json'])
+                ->post($this->endpoint, ['streams' => array_values($streams)]);
+        } catch (\Throwable $e) {
+            try {
+                \Illuminate\Support\Facades\Log::channel('single')->warning(
+                    'Loki audit push failed',
+                    ['error' => $e->getMessage(), 'endpoint' => $this->endpoint]
+                );
+            } catch (\Throwable) {
+            }
+        }
+    }
+
+    public function close(): void
+    {
+        $this->flush();
+        parent::close();
+    }
+}

--- a/Programming/WebBackEnd/app/Logging/LokiJsonFormatter.php
+++ b/Programming/WebBackEnd/app/Logging/LokiJsonFormatter.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+class LokiJsonFormatter implements FormatterInterface
+{
+    private const REDACT_REGEX = '/(password|token|authorization|x-api-key|cookie|secret)/i';
+    private const DEFAULT_MAX_BYTES = 65536;
+
+    public function format(LogRecord $record): array
+    {
+        $context = $record->context;
+
+        $labels = [];
+        if (isset($context['phase'])) {
+            $labels['phase'] = (string) $context['phase'];
+        }
+        if (isset($context['method'])) {
+            $labels['method'] = (string) $context['method'];
+        }
+        if (isset($context['response_status'])) {
+            $code = (int) $context['response_status'];
+            $labels['status'] = match (true) {
+                $code >= 500 => '5xx',
+                $code >= 400 => '4xx',
+                $code >= 300 => '3xx',
+                $code >= 200 => '2xx',
+                default      => 'other',
+            };
+        }
+
+        $maxBytes = (int) (env('LOKI_MAX_FIELD_BYTES') ?: self::DEFAULT_MAX_BYTES);
+        $payload = $this->sanitize($context, $maxBytes);
+        $payload['ts']  = $record->datetime->format('c');
+        $payload['msg'] = $record->message;
+
+        $line = json_encode(
+            $payload,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR
+        );
+        if ($line === false) {
+            $line = '{"_error":"json_encode_failed"}';
+        }
+
+        $tsNs = sprintf(
+            '%d%09d',
+            $record->datetime->getTimestamp(),
+            ((int) $record->datetime->format('u')) * 1000
+        );
+
+        return ['labels' => $labels, 'tuple' => [$tsNs, $line]];
+    }
+
+    public function formatBatch(array $records): array
+    {
+        return array_map(fn (LogRecord $r) => $this->format($r), $records);
+    }
+
+    private function sanitize(mixed $value, int $maxBytes): mixed
+    {
+        if (is_array($value)) {
+            $out = [];
+            foreach ($value as $k => $v) {
+                if (is_string($k) && preg_match(self::REDACT_REGEX, $k)) {
+                    $out[$k] = '[REDACTED]';
+                    continue;
+                }
+                $out[$k] = $this->sanitize($v, $maxBytes);
+            }
+            return $out;
+        }
+        if (is_string($value) && strlen($value) > $maxBytes) {
+            return substr($value, 0, $maxBytes) . '...[truncated]';
+        }
+        return $value;
+    }
+}

--- a/Programming/WebBackEnd/config/logging.php
+++ b/Programming/WebBackEnd/config/logging.php
@@ -37,7 +37,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
             'ignore_exceptions' => false,
         ],
 
@@ -98,6 +98,22 @@ return [
 
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
+        ],
+
+        'loki' => [
+            'driver'    => 'monolog',
+            'handler'   => \App\Logging\LokiHandler::class,
+            'with'      => [
+                'endpoint' => env('LOKI_PUSH_URL', 'http://grafana-loki:3100/loki/api/v1/push'),
+                'timeout'  => (float) env('LOKI_TIMEOUT', 0.25),
+                'labels'   => [
+                    'app' => 'erp_reborn',
+                    'env' => env('APP_ENV', 'production'),
+                    'job' => 'laravel',
+                ],
+            ],
+            'formatter' => \Monolog\Formatter\JsonFormatter::class,
+            'level'     => env('LOG_LEVEL', 'debug'),
         ],
 
         'audit_api' => [


### PR DESCRIPTION
## Summary
- Mirrors logging config from `WebBackEnd_LaravelOctane_FrankenPHP` (merged in #1551)
- Stack channels now driven by `LOG_STACK` env var (default: `single` — no behaviour change)
- Adds `loki` channel via `LokiHandler` for direct push to Grafana Loki

## How to activate on dev
```env
LOG_STACK=single,loki
LOKI_PUSH_URL=http://172.28.0.111:3100/loki/api/v1/push
```

## Test plan
- [ ] Prod: verify no change — `LOG_STACK` unset, defaults to `single` as before
- [ ] Dev: set `LOG_STACK=single,loki`, trigger a log entry, confirm it appears in Grafana under `job=laravel`
- [ ] Confirm `audit_api` channel unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)