### PR TITLE
perf(db): query execution — 5→1 round-trips + persistent connection (audit Q1, Q3, Q4)

### DIFF
--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
@@ -206,7 +206,11 @@ namespace App\Helpers\ZhtHelper\Database
                         $i=0;
                         $varData = [];
                         $varNotice = null;
-                        if($DBConnection = @pg_connect($varConnectionString))
+                        //---> [PERF Q4] Use a persistent connection (pg_pconnect) reused across queries instead
+                        //     of pg_connect()+pg_close() per query, which forced a Postgres backend-fork on
+                        //     every call. The connection is pooled per PHP worker and is NOT closed per query;
+                        //     notices are cleared per query (PGSQL_NOTICE_CLEAR below) so reuse stays clean.
+                        if($DBConnection = @pg_pconnect($varConnectionString))
                             {
                             /*
                             var_dump($varConnectionString);
@@ -231,8 +235,9 @@ namespace App\Helpers\ZhtHelper\Database
                             //     pg_num_fields(false) raise a TypeError in the fetch loop below.
                             if ($varResult === false)
                                 {
+                                //---> [PERF Q4] Do not close the persistent connection; a failed statement in
+                                //     autocommit leaves it healthy for reuse by the next query.
                                 $varErrorMessage = pg_last_error($DBConnection);
-                                pg_close($DBConnection);
                                 throw new \Exception('Incorrect SQL syntax: '.$varErrorMessage);
                                 }
 
@@ -300,7 +305,7 @@ namespace App\Helpers\ZhtHelper\Database
                                 //$varData[$i] = $varDataContent;
                                 $i++;
                                 }
-                            pg_close($DBConnection);
+                            //---> [PERF Q4] Persistent connection kept open for reuse (no per-query pg_close).
                             }
                         else
                             {
@@ -949,7 +954,7 @@ namespace App\Helpers\ZhtHelper\Database
                         //echo $varSQLQuery."<br><br>";
                         //---> [PERF Q1] Dropped the "SELECT 1" availability probe (getStatusAvailability)
                         //     to remove one DB round-trip per query. Connectivity is now enforced at the
-                        //     real pg_connect() below (getArrayFromQueryExecutionDataFetch_UsingPGSQLConnection),
+                        //     real pg_pconnect() below (getArrayFromQueryExecutionDataFetch_UsingPGSQLConnection),
                         //     which throws 'Database connection is not available' when the connection fails.
                             //---> [PERF Q3] Dropped the pre-query isValid_SQLSyntax() round-trip.
                             //     That server-side probe only ran PREPARE/DEALLOCATE to test parseability

--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
@@ -217,7 +217,7 @@ namespace App\Helpers\ZhtHelper\Database
 
                             pg_last_notice($DBConnection, PGSQL_NOTICE_CLEAR);
                             $varProfilerStartNs = hrtime(true);
-                            $varResult = pg_query($DBConnection, $varSQLQuery);
+                            $varResult = @pg_query($DBConnection, $varSQLQuery);
                             \App\Helpers\ZhtHelper\Logger\Helper_QueryProfiler::record(
                                 'pgsql',
                                 $varSQLQuery,
@@ -225,6 +225,17 @@ namespace App\Helpers\ZhtHelper\Database
                                 ($varResult !== false),
                                 ($varResult === false ? pg_last_error($DBConnection) : null)
                                 );
+
+                            //---> [PERF Q3] Now that the pre-query syntax-validation probe is removed, an
+                            //     invalid statement surfaces here. Fail cleanly instead of letting
+                            //     pg_num_fields(false) raise a TypeError in the fetch loop below.
+                            if ($varResult === false)
+                                {
+                                $varErrorMessage = pg_last_error($DBConnection);
+                                pg_close($DBConnection);
+                                throw new \Exception('Incorrect SQL syntax: '.$varErrorMessage);
+                                }
+
                             $varNotice = pg_last_notice($DBConnection, PGSQL_NOTICE_ALL);
 
                             /*
@@ -940,14 +951,11 @@ namespace App\Helpers\ZhtHelper\Database
                         //     to remove one DB round-trip per query. Connectivity is now enforced at the
                         //     real pg_connect() below (getArrayFromQueryExecutionDataFetch_UsingPGSQLConnection),
                         //     which throws 'Database connection is not available' when the connection fails.
-                            //---> Cek apakah SQLQuery Proper
-                            if (self::isValid_SQLSyntax($varUserSession, $varSQLQuery) == FALSE)
-                                {
-                                throw
-                                    new \Exception('Incorrect SQL syntax');
-                                }
-                            else
-                                {
+                            //---> [PERF Q3] Dropped the pre-query isValid_SQLSyntax() round-trip.
+                            //     That server-side probe only ran PREPARE/DEALLOCATE to test parseability
+                            //     (not a security gate) and was redundant with executing the query. An
+                            //     invalid statement is now caught at the real pg_query() below, which raises
+                            //     'Incorrect SQL syntax'. (isValid_SQLSyntax() is kept for its other callers.)
                                 $varReturn['process']['DBMS']['executionTime']['interval'] = NULL;
 
                                 //---> Inisialisasi [Process][StartDateTime]
@@ -991,7 +999,6 @@ namespace App\Helpers\ZhtHelper\Database
                                         $varReturn['process']['DBMS']['executionTime']['startDateTimeTZ'],
                                         $varReturn['process']['DBMS']['executionTime']['finishDateTimeTZ']
                                         );
-                                }
                         }
                     //---- ( MAIN CODE ) ----------------------------------------------------------------------- [ END POINT ] -----
                     \App\Helpers\ZhtHelper\Logger\Helper_SystemLog::setLogOutputMethodProcessStatus($varUserSession, $varSysDataProcess, 'Success');

--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
@@ -944,27 +944,14 @@ namespace App\Helpers\ZhtHelper\Database
                                 $varReturn['process']['DBMS']['executionTime']['interval'] = NULL;
 
                                 //---> Inisialisasi [Process][StartDateTime]
-                                $varDataTemp = 
-                                    self::getArrayFromQueryExecutionDataFetch_UsingLaravelConnection(
-                                        $varUserSession, 
-                                        "SELECT NOW();"
-                                        );
-                                $varTempExplode = explode('+', $varDataTemp['data'][0]['now']);
-
-                                /*
-                                $varReturn['process']['DBMS']['executionTime']['startDateTimeTZ'] = (
-                                    str_pad($varTempExplode[0], 26, '0', STR_PAD_RIGHT).
-                                    ((($varTempExplode[1] * 1) < 0) ? '-' : '+').
-                                    $varTempExplode[1]
-                                    );
-                                */
+                                //---> [PERF Q1] Removed the redundant "SELECT NOW();" DB round-trip.
+                                //     The start timestamp is taken from the PHP clock (new \DateTime()) below;
+                                //     the previously-fetched SQL NOW() value was discarded (dead work).
                                 $varReturn['process']['DBMS']['executionTime']['startDateTimeTZ'] =
                                     \App\Helpers\ZhtHelper\General\Helper_DateTime::getTimeStampTZConvert_PHPDateTimeToDateTimeTZString(
                                         \App\Helpers\ZhtHelper\System\Helper_Environment::getUserSessionID_System(),
                                         (new \DateTime())
                                         );
-
-                                unset($varDataTemp);
 
                                 //---> Inisialisasi [Data], [RowCount], [Notice]
                                 //$varDataTemp = self::getArrayFromQueryExecutionDataFetch_UsingLaravelConnection($varUserSession, $varSQLQuery);
@@ -980,30 +967,10 @@ namespace App\Helpers\ZhtHelper\Database
 
                                 unset($varDataTemp);
                                 
-                                //---> Inisialisasi [Process][StartDateTime]
-                                $varDataTemp = 
-                                    self::getArrayFromQueryExecutionDataFetch_UsingLaravelConnection(
-                                        $varUserSession,
-                                        "
-                                        SELECT
-                                            \"SubSQL\".now AS \"FinishDateTimeTZ\",
-                                            (\"SubSQL\".now - '".$varReturn['process']['DBMS']['executionTime']['startDateTimeTZ']."')::interval AS \"ExecutionInterval\"
-                                        FROM
-                                            (
-                                            SELECT NOW()
-                                            ) AS \"SubSQL\"
-                                        "
-                                        );
-                                
                                 //---> Inisialisasi : varReturn[process][DBMS][finishDateTimeTZ]
-                                /*
-                                $varTempExplode = explode('+', $varDataTemp['data'][0]['FinishDateTimeTZ']);
-                                $varReturn['process']['DBMS']['executionTime']['finishDateTimeTZ'] = (
-                                    str_pad($varTempExplode[0], 26, '0', STR_PAD_RIGHT).
-                                    ((($varTempExplode[1] * 1) < 0) ? '-' : '+').
-                                    $varTempExplode[1]
-                                    );
-                                */
+                                //---> [PERF Q1] Removed the redundant "SELECT NOW() ... ::interval" DB round-trip.
+                                //     The finish timestamp is taken from the PHP clock (new \DateTime()) below and the
+                                //     interval is computed in PHP; the previously-fetched SQL values were discarded.
                                 $varReturn['process']['DBMS']['executionTime']['finishDateTimeTZ'] =
                                     \App\Helpers\ZhtHelper\General\Helper_DateTime::getTimeStampTZConvert_PHPDateTimeToDateTimeTZString(
                                         \App\Helpers\ZhtHelper\System\Helper_Environment::getUserSessionID_System(),
@@ -1011,22 +978,12 @@ namespace App\Helpers\ZhtHelper\Database
                                         );
 
                                 //---> Inisialisasi : varReturn[process][DBMS][executionInterval]
-                                /*
-                                $varTempExplode = explode('.', $varDataTemp['data'][0]['ExecutionInterval']);                                
-                                $varReturn['process']['DBMS']['executionTime']['interval'] = (
-                                    $varTempExplode[0].
-                                    '.'.
-                                     str_pad($varTempExplode[1], 6, '0', STR_PAD_RIGHT)
-                                    );
-                                */
-                                $varReturn['process']['DBMS']['executionTime']['interval'] = 
+                                $varReturn['process']['DBMS']['executionTime']['interval'] =
                                      \App\Helpers\ZhtHelper\General\Helper_DateTime::getDifferenceOfDateTimeTZString(
                                         $varUserSession,
                                         $varReturn['process']['DBMS']['executionTime']['startDateTimeTZ'],
                                         $varReturn['process']['DBMS']['executionTime']['finishDateTimeTZ']
                                         );
-                                
-                                unset($varDataTemp);
                                 }
                             }
                         else

--- a/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
+++ b/Programming/.LaravelCore/app/Helpers/ZhtHelper/Database/Helper_PostgreSQL.php
@@ -206,7 +206,7 @@ namespace App\Helpers\ZhtHelper\Database
                         $i=0;
                         $varData = [];
                         $varNotice = null;
-                        if($DBConnection = pg_connect($varConnectionString))
+                        if($DBConnection = @pg_connect($varConnectionString))
                             {
                             /*
                             var_dump($varConnectionString);
@@ -290,6 +290,13 @@ namespace App\Helpers\ZhtHelper\Database
                                 $i++;
                                 }
                             pg_close($DBConnection);
+                            }
+                        else
+                            {
+                            //---> [PERF Q1] Now that the pre-query "SELECT 1" probe is removed, availability
+                            //     is enforced here: a failed connection raises a clean, logged error instead
+                            //     of silently returning an empty result set.
+                            throw new \Exception('Database connection is not available');
                             }
 
                         $varReturn['data'] = $varData;
@@ -929,10 +936,10 @@ namespace App\Helpers\ZhtHelper\Database
                         $varSQLQuery = ltrim(str_replace("\n", "" , $varSQLQuery));
 
                         //echo $varSQLQuery."<br><br>";
-                        if (self::getStatusAvailability($varUserSession) == true)
-                            {
-//echo $varSQLQuery."<br><br>";
-//echo $varSQLQuery;
+                        //---> [PERF Q1] Dropped the "SELECT 1" availability probe (getStatusAvailability)
+                        //     to remove one DB round-trip per query. Connectivity is now enforced at the
+                        //     real pg_connect() below (getArrayFromQueryExecutionDataFetch_UsingPGSQLConnection),
+                        //     which throws 'Database connection is not available' when the connection fails.
                             //---> Cek apakah SQLQuery Proper
                             if (self::isValid_SQLSyntax($varUserSession, $varSQLQuery) == FALSE)
                                 {
@@ -985,12 +992,6 @@ namespace App\Helpers\ZhtHelper\Database
                                         $varReturn['process']['DBMS']['executionTime']['finishDateTimeTZ']
                                         );
                                 }
-                            }
-                        else
-                            {
-                            throw
-                                new \Exception('Database connection is not available');
-                            }
                         }
                     //---- ( MAIN CODE ) ----------------------------------------------------------------------- [ END POINT ] -----
                     \App\Helpers\ZhtHelper\Logger\Helper_SystemLog::setLogOutputMethodProcessStatus($varUserSession, $varSysDataProcess, 'Success');


### PR DESCRIPTION
## Summary
Optimizes the central query-execution path (`Helper_PostgreSQL.php`), which every model/stored-proc call funnels through (~294 call sites). Fixes audit findings **Q1**, **Q3**, and **Q4**.

- **Q1 + Q3:** `getQueryExecution()` went from **5 DB round-trips per query to 1** (just the real query).
- **Q4:** the native connection is now **persistent/reused** instead of opened+closed per query.

## Round-trip reduction (Q1 + Q3)
| # | Round-trip | Status |
|---|-----------|--------|
| 1 | `SELECT 1` availability probe (`getStatusAvailability`) | **removed** (Q1) |
| 2 | server-side SQL syntax-validation proc (`isValid_SQLSyntax`) | **removed** (Q3) |
| 3 | `SELECT NOW()` — start timestamp | **removed** (Q1) |
| 4 | the real query | kept |
| 5 | `SELECT NOW() … ::interval` — finish timestamp | **removed** (Q1) |

## Connection reuse (Q4)
`getArrayFromQueryExecutionDataFetch_UsingPGSQLConnection()` opened a fresh `pg_connect()` and `pg_close()`d it **every query**, forcing a Postgres backend-fork per call. Now uses **`pg_pconnect()`** (persistent, pooled per PHP worker) with both per-query `pg_close()` calls removed. Notices are cleared per query (`PGSQL_NOTICE_CLEAR`) so reuse stays clean; a failed statement in autocommit leaves the connection healthy, and `pg_pconnect` resets a dead persistent connection on next use.

## Commits
1. Remove the two `SELECT NOW()` round-trips (timestamps already come from PHP `new \DateTime()`).
2. Drop the `SELECT 1` availability probe; availability now enforced at the real connection (`@pg_connect`/`@pg_pconnect` → throws `Database connection is not available` on failure).
3. Drop the pre-query syntax-validation proc (only a `PREPARE`/`DEALLOCATE` parseability check, verified against the DB structure dump — not a security gate); invalid SQL now caught at the real `pg_query()` (throws `Incorrect SQL syntax: <pg_last_error>`, and prevents a `pg_num_fields(false)` TypeError).
4. Reuse a persistent `pg_pconnect()` connection instead of connect/close per query.

## Preserved / out of scope
- `getStatusAvailability()` and `isValid_SQLSyntax()` methods are **kept** — each has other callers (`isValid_SQLSyntax` still validates user-supplied WHERE/ORDER BY fragments in `Helper_SQLValidation`).
- Per-row×per-column cast loop (audit **Q5**) is untouched — a separate follow-up.
- Persistent connections consume server-side slots; pairs naturally with adding PgBouncer (audit C3) and `statement_timeout` (C4).

## Verification
- `php -l` → **No syntax errors detected** after each change.
- Error paths preserved: empty SQL → `Incorrect SQL syntax`; unparseable SQL → clean throw at `pg_query()`; dead connection → clean throw at connect. The `is_null(config)` Laravel-fallback branch is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)